### PR TITLE
Fix the handling of %T, make Print() behave like in fmt

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,52 @@
+Overall code structure
+======================
+
+This directory imports the "printf" logic as-is from the Go standard
+library and instruments it for redaction of sensitive data.
+
+Overall, the original Go code is structured as follows:
+
+- the top-level API functions (`Printf` `Fprintf` etc) instantiate a
+  "printer" struct called `pp`, then call the `doPrint*()` methods
+  on it.
+
+- the `pp` contains a byte slice (`pp.buf`, type `buffer`) that
+  accumulates the result of formatting *regardless of the final output
+  of the API* - i.e. a buffer is used even when using `Fprint` to an
+  `io.Writer`. Only after the `doPrint()` method finishes, is the
+  `buffer` copied to the final `io.Writer` in the `Fprint*` variants.
+
+- each of the `doPrint` methods does some analysis on the argument
+  list - quite simple for e.g. `doPrintln`, more intricate for
+  `doPrintf`.  As part of the analysis it emits "spacing" or no-op
+  bytes directly on the `pp.buf`. For example `doPrint` emits spaces
+  between arguments directly, `doPrintf` emits the non-formatting
+  characters from the format string, as well as certain *constant*
+  error strings (e.g. `%(BADPREC)`).
+
+At this point **we make the following assumption**: there is no data
+from the printed *arguments* that is emitted to `pp.buf` directly by a
+`doPrint()` method. This is true of the implementation as of Go 1.14.
+
+From this point, this package contains a *custom patch* onto the
+default implementation: the calls to `p.printArg` performed by the
+`doPrint()` methods are redirected to a function callback that is
+injected by the `redact` package.
+
+Refreshing the sources
+======================
+
+The files in this directory have been imported from
+
+`$GOROOT/src/fmt/{format,print}.go`
+
+and
+
+`$GOROOT/src/internal/fmtsort`
+
+And patched using the included `.diff` files.
+
+To upgrade to a newer Go implementation, import the files anew and
+re-apply the patches.
+
+See the script `refresh.sh` for details.

--- a/internal/fmtsort/sort.go
+++ b/internal/fmtsort/sort.go
@@ -1,0 +1,222 @@
+// Code generated from the Go standard library. DO NOT EDIT
+// GENERATED FILE DO NOT EDIT
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package fmtsort provides a general stable ordering mechanism
+// for maps, on behalf of the fmt and text/template packages.
+// It is not guaranteed to be efficient and works only for types
+// that are valid map keys.
+package fmtsort
+
+import (
+	"reflect"
+	"sort"
+)
+
+// Note: Throughout this package we avoid calling reflect.Value.Interface as
+// it is not always legal to do so and it's easier to avoid the issue than to face it.
+
+// SortedMap represents a map's keys and values. The keys and values are
+// aligned in index order: Value[i] is the value in the map corresponding to Key[i].
+type SortedMap struct {
+	Key   []reflect.Value
+	Value []reflect.Value
+}
+
+func (o *SortedMap) Len() int           { return len(o.Key) }
+func (o *SortedMap) Less(i, j int) bool { return compare(o.Key[i], o.Key[j]) < 0 }
+func (o *SortedMap) Swap(i, j int) {
+	o.Key[i], o.Key[j] = o.Key[j], o.Key[i]
+	o.Value[i], o.Value[j] = o.Value[j], o.Value[i]
+}
+
+// Sort accepts a map and returns a SortedMap that has the same keys and
+// values but in a stable sorted order according to the keys, modulo issues
+// raised by unorderable key values such as NaNs.
+//
+// The ordering rules are more general than with Go's < operator:
+//
+//  - when applicable, nil compares low
+//  - ints, floats, and strings order by <
+//  - NaN compares less than non-NaN floats
+//  - bool compares false before true
+//  - complex compares real, then imag
+//  - pointers compare by machine address
+//  - channel values compare by machine address
+//  - structs compare each field in turn
+//  - arrays compare each element in turn.
+//    Otherwise identical arrays compare by length.
+//  - interface values compare first by reflect.Type describing the concrete type
+//    and then by concrete value as described in the previous rules.
+//
+func Sort(mapValue reflect.Value) *SortedMap {
+	if mapValue.Type().Kind() != reflect.Map {
+		return nil
+	}
+	// Note: this code is arranged to not panic even in the presence
+	// of a concurrent map update. The runtime is responsible for
+	// yelling loudly if that happens. See issue 33275.
+	n := mapValue.Len()
+	key := make([]reflect.Value, 0, n)
+	value := make([]reflect.Value, 0, n)
+	iter := mapValue.MapRange()
+	for iter.Next() {
+		key = append(key, iter.Key())
+		value = append(value, iter.Value())
+	}
+	sorted := &SortedMap{
+		Key:   key,
+		Value: value,
+	}
+	sort.Stable(sorted)
+	return sorted
+}
+
+// compare compares two values of the same type. It returns -1, 0, 1
+// according to whether a > b (1), a == b (0), or a < b (-1).
+// If the types differ, it returns -1.
+// See the comment on Sort for the comparison rules.
+func compare(aVal, bVal reflect.Value) int {
+	aType, bType := aVal.Type(), bVal.Type()
+	if aType != bType {
+		return -1 // No good answer possible, but don't return 0: they're not equal.
+	}
+	switch aVal.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		a, b := aVal.Int(), bVal.Int()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		a, b := aVal.Uint(), bVal.Uint()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.String:
+		a, b := aVal.String(), bVal.String()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Float32, reflect.Float64:
+		return floatCompare(aVal.Float(), bVal.Float())
+	case reflect.Complex64, reflect.Complex128:
+		a, b := aVal.Complex(), bVal.Complex()
+		if c := floatCompare(real(a), real(b)); c != 0 {
+			return c
+		}
+		return floatCompare(imag(a), imag(b))
+	case reflect.Bool:
+		a, b := aVal.Bool(), bVal.Bool()
+		switch {
+		case a == b:
+			return 0
+		case a:
+			return 1
+		default:
+			return -1
+		}
+	case reflect.Ptr:
+		a, b := aVal.Pointer(), bVal.Pointer()
+		switch {
+		case a < b:
+			return -1
+		case a > b:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Chan:
+		if c, ok := nilCompare(aVal, bVal); ok {
+			return c
+		}
+		ap, bp := aVal.Pointer(), bVal.Pointer()
+		switch {
+		case ap < bp:
+			return -1
+		case ap > bp:
+			return 1
+		default:
+			return 0
+		}
+	case reflect.Struct:
+		for i := 0; i < aVal.NumField(); i++ {
+			if c := compare(aVal.Field(i), bVal.Field(i)); c != 0 {
+				return c
+			}
+		}
+		return 0
+	case reflect.Array:
+		for i := 0; i < aVal.Len(); i++ {
+			if c := compare(aVal.Index(i), bVal.Index(i)); c != 0 {
+				return c
+			}
+		}
+		return 0
+	case reflect.Interface:
+		if c, ok := nilCompare(aVal, bVal); ok {
+			return c
+		}
+		c := compare(reflect.ValueOf(aVal.Elem().Type()), reflect.ValueOf(bVal.Elem().Type()))
+		if c != 0 {
+			return c
+		}
+		return compare(aVal.Elem(), bVal.Elem())
+	default:
+		// Certain types cannot appear as keys (maps, funcs, slices), but be explicit.
+		panic("bad type in compare: " + aType.String())
+	}
+}
+
+// nilCompare checks whether either value is nil. If not, the boolean is false.
+// If either value is nil, the boolean is true and the integer is the comparison
+// value. The comparison is defined to be 0 if both are nil, otherwise the one
+// nil value compares low. Both arguments must represent a chan, func,
+// interface, map, pointer, or slice.
+func nilCompare(aVal, bVal reflect.Value) (int, bool) {
+	if aVal.IsNil() {
+		if bVal.IsNil() {
+			return 0, true
+		}
+		return -1, true
+	}
+	if bVal.IsNil() {
+		return 1, true
+	}
+	return 0, false
+}
+
+// floatCompare compares two floating-point values. NaNs compare low.
+func floatCompare(a, b float64) int {
+	switch {
+	case isNaN(a):
+		return -1 // No good answer if b is a NaN so don't bother checking.
+	case isNaN(b):
+		return 1
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	}
+	return 0
+}
+
+func isNaN(a float64) bool {
+	return a != a
+}

--- a/internal/format.go
+++ b/internal/format.go
@@ -1,0 +1,584 @@
+// Code generated from the Go standard library. DO NOT EDIT
+// GENERATED FILE DO NOT EDIT
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	"strconv"
+	"unicode/utf8"
+)
+
+const (
+	ldigits = "0123456789abcdefx"
+	udigits = "0123456789ABCDEFX"
+)
+
+const (
+	signed   = true
+	unsigned = false
+)
+
+// flags placed in a separate struct for easy clearing.
+type fmtFlags struct {
+	widPresent  bool
+	precPresent bool
+	minus       bool
+	plus        bool
+	sharp       bool
+	space       bool
+	zero        bool
+
+	// For the formats %+v %#v, we set the plusV/sharpV flags
+	// and clear the plus/sharp flags since %+v and %#v are in effect
+	// different, flagless formats set at the top level.
+	plusV  bool
+	sharpV bool
+}
+
+// A fmt is the raw formatter used by Printf etc.
+// It prints into a buffer that must be set up separately.
+type fmt struct {
+	buf *buffer
+
+	fmtFlags
+
+	wid  int // width
+	prec int // precision
+
+	// intbuf is large enough to store %b of an int64 with a sign and
+	// avoids padding at the end of the struct on 32 bit architectures.
+	intbuf [68]byte
+}
+
+func (f *fmt) clearflags() {
+	f.fmtFlags = fmtFlags{}
+}
+
+func (f *fmt) init(buf *buffer) {
+	f.buf = buf
+	f.clearflags()
+}
+
+// writePadding generates n bytes of padding.
+func (f *fmt) writePadding(n int) {
+	if n <= 0 { // No padding bytes needed.
+		return
+	}
+	buf := *f.buf
+	oldLen := len(buf)
+	newLen := oldLen + n
+	// Make enough room for padding.
+	if newLen > cap(buf) {
+		buf = make(buffer, cap(buf)*2+n)
+		copy(buf, *f.buf)
+	}
+	// Decide which byte the padding should be filled with.
+	padByte := byte(' ')
+	if f.zero {
+		padByte = byte('0')
+	}
+	// Fill padding with padByte.
+	padding := buf[oldLen:newLen]
+	for i := range padding {
+		padding[i] = padByte
+	}
+	*f.buf = buf[:newLen]
+}
+
+// pad appends b to f.buf, padded on left (!f.minus) or right (f.minus).
+func (f *fmt) pad(b []byte) {
+	if !f.widPresent || f.wid == 0 {
+		f.buf.write(b)
+		return
+	}
+	width := f.wid - utf8.RuneCount(b)
+	if !f.minus {
+		// left padding
+		f.writePadding(width)
+		f.buf.write(b)
+	} else {
+		// right padding
+		f.buf.write(b)
+		f.writePadding(width)
+	}
+}
+
+// padString appends s to f.buf, padded on left (!f.minus) or right (f.minus).
+func (f *fmt) padString(s string) {
+	if !f.widPresent || f.wid == 0 {
+		f.buf.writeString(s)
+		return
+	}
+	width := f.wid - utf8.RuneCountInString(s)
+	if !f.minus {
+		// left padding
+		f.writePadding(width)
+		f.buf.writeString(s)
+	} else {
+		// right padding
+		f.buf.writeString(s)
+		f.writePadding(width)
+	}
+}
+
+// fmtBoolean formats a boolean.
+func (f *fmt) fmtBoolean(v bool) {
+	if v {
+		f.padString("true")
+	} else {
+		f.padString("false")
+	}
+}
+
+// fmtUnicode formats a uint64 as "U+0078" or with f.sharp set as "U+0078 'x'".
+func (f *fmt) fmtUnicode(u uint64) {
+	buf := f.intbuf[0:]
+
+	// With default precision set the maximum needed buf length is 18
+	// for formatting -1 with %#U ("U+FFFFFFFFFFFFFFFF") which fits
+	// into the already allocated intbuf with a capacity of 68 bytes.
+	prec := 4
+	if f.precPresent && f.prec > 4 {
+		prec = f.prec
+		// Compute space needed for "U+" , number, " '", character, "'".
+		width := 2 + prec + 2 + utf8.UTFMax + 1
+		if width > len(buf) {
+			buf = make([]byte, width)
+		}
+	}
+
+	// Format into buf, ending at buf[i]. Formatting numbers is easier right-to-left.
+	i := len(buf)
+
+	// For %#U we want to add a space and a quoted character at the end of the buffer.
+	if f.sharp && u <= utf8.MaxRune && strconv.IsPrint(rune(u)) {
+		i--
+		buf[i] = '\''
+		i -= utf8.RuneLen(rune(u))
+		utf8.EncodeRune(buf[i:], rune(u))
+		i--
+		buf[i] = '\''
+		i--
+		buf[i] = ' '
+	}
+	// Format the Unicode code point u as a hexadecimal number.
+	for u >= 16 {
+		i--
+		buf[i] = udigits[u&0xF]
+		prec--
+		u >>= 4
+	}
+	i--
+	buf[i] = udigits[u]
+	prec--
+	// Add zeros in front of the number until requested precision is reached.
+	for prec > 0 {
+		i--
+		buf[i] = '0'
+		prec--
+	}
+	// Add a leading "U+".
+	i--
+	buf[i] = '+'
+	i--
+	buf[i] = 'U'
+
+	oldZero := f.zero
+	f.zero = false
+	f.pad(buf[i:])
+	f.zero = oldZero
+}
+
+// fmtInteger formats signed and unsigned integers.
+func (f *fmt) fmtInteger(u uint64, base int, isSigned bool, verb rune, digits string) {
+	negative := isSigned && int64(u) < 0
+	if negative {
+		u = -u
+	}
+
+	buf := f.intbuf[0:]
+	// The already allocated f.intbuf with a capacity of 68 bytes
+	// is large enough for integer formatting when no precision or width is set.
+	if f.widPresent || f.precPresent {
+		// Account 3 extra bytes for possible addition of a sign and "0x".
+		width := 3 + f.wid + f.prec // wid and prec are always positive.
+		if width > len(buf) {
+			// We're going to need a bigger boat.
+			buf = make([]byte, width)
+		}
+	}
+
+	// Two ways to ask for extra leading zero digits: %.3d or %03d.
+	// If both are specified the f.zero flag is ignored and
+	// padding with spaces is used instead.
+	prec := 0
+	if f.precPresent {
+		prec = f.prec
+		// Precision of 0 and value of 0 means "print nothing" but padding.
+		if prec == 0 && u == 0 {
+			oldZero := f.zero
+			f.zero = false
+			f.writePadding(f.wid)
+			f.zero = oldZero
+			return
+		}
+	} else if f.zero && f.widPresent {
+		prec = f.wid
+		if negative || f.plus || f.space {
+			prec-- // leave room for sign
+		}
+	}
+
+	// Because printing is easier right-to-left: format u into buf, ending at buf[i].
+	// We could make things marginally faster by splitting the 32-bit case out
+	// into a separate block but it's not worth the duplication, so u has 64 bits.
+	i := len(buf)
+	// Use constants for the division and modulo for more efficient code.
+	// Switch cases ordered by popularity.
+	switch base {
+	case 10:
+		for u >= 10 {
+			i--
+			next := u / 10
+			buf[i] = byte('0' + u - next*10)
+			u = next
+		}
+	case 16:
+		for u >= 16 {
+			i--
+			buf[i] = digits[u&0xF]
+			u >>= 4
+		}
+	case 8:
+		for u >= 8 {
+			i--
+			buf[i] = byte('0' + u&7)
+			u >>= 3
+		}
+	case 2:
+		for u >= 2 {
+			i--
+			buf[i] = byte('0' + u&1)
+			u >>= 1
+		}
+	default:
+		panic("fmt: unknown base; can't happen")
+	}
+	i--
+	buf[i] = digits[u]
+	for i > 0 && prec > len(buf)-i {
+		i--
+		buf[i] = '0'
+	}
+
+	// Various prefixes: 0x, -, etc.
+	if f.sharp {
+		switch base {
+		case 2:
+			// Add a leading 0b.
+			i--
+			buf[i] = 'b'
+			i--
+			buf[i] = '0'
+		case 8:
+			if buf[i] != '0' {
+				i--
+				buf[i] = '0'
+			}
+		case 16:
+			// Add a leading 0x or 0X.
+			i--
+			buf[i] = digits[16]
+			i--
+			buf[i] = '0'
+		}
+	}
+	if verb == 'O' {
+		i--
+		buf[i] = 'o'
+		i--
+		buf[i] = '0'
+	}
+
+	if negative {
+		i--
+		buf[i] = '-'
+	} else if f.plus {
+		i--
+		buf[i] = '+'
+	} else if f.space {
+		i--
+		buf[i] = ' '
+	}
+
+	// Left padding with zeros has already been handled like precision earlier
+	// or the f.zero flag is ignored due to an explicitly set precision.
+	oldZero := f.zero
+	f.zero = false
+	f.pad(buf[i:])
+	f.zero = oldZero
+}
+
+// truncate truncates the string s to the specified precision, if present.
+func (f *fmt) truncateString(s string) string {
+	if f.precPresent {
+		n := f.prec
+		for i := range s {
+			n--
+			if n < 0 {
+				return s[:i]
+			}
+		}
+	}
+	return s
+}
+
+// truncate truncates the byte slice b as a string of the specified precision, if present.
+func (f *fmt) truncate(b []byte) []byte {
+	if f.precPresent {
+		n := f.prec
+		for i := 0; i < len(b); {
+			n--
+			if n < 0 {
+				return b[:i]
+			}
+			wid := 1
+			if b[i] >= utf8.RuneSelf {
+				_, wid = utf8.DecodeRune(b[i:])
+			}
+			i += wid
+		}
+	}
+	return b
+}
+
+// fmtS formats a string.
+func (f *fmt) fmtS(s string) {
+	s = f.truncateString(s)
+	f.padString(s)
+}
+
+// fmtBs formats the byte slice b as if it was formatted as string with fmtS.
+func (f *fmt) fmtBs(b []byte) {
+	b = f.truncate(b)
+	f.pad(b)
+}
+
+// fmtSbx formats a string or byte slice as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtSbx(s string, b []byte, digits string) {
+	length := len(b)
+	if b == nil {
+		// No byte slice present. Assume string s should be encoded.
+		length = len(s)
+	}
+	// Set length to not process more bytes than the precision demands.
+	if f.precPresent && f.prec < length {
+		length = f.prec
+	}
+	// Compute width of the encoding taking into account the f.sharp and f.space flag.
+	width := 2 * length
+	if width > 0 {
+		if f.space {
+			// Each element encoded by two hexadecimals will get a leading 0x or 0X.
+			if f.sharp {
+				width *= 2
+			}
+			// Elements will be separated by a space.
+			width += length - 1
+		} else if f.sharp {
+			// Only a leading 0x or 0X will be added for the whole string.
+			width += 2
+		}
+	} else { // The byte slice or string that should be encoded is empty.
+		if f.widPresent {
+			f.writePadding(f.wid)
+		}
+		return
+	}
+	// Handle padding to the left.
+	if f.widPresent && f.wid > width && !f.minus {
+		f.writePadding(f.wid - width)
+	}
+	// Write the encoding directly into the output buffer.
+	buf := *f.buf
+	if f.sharp {
+		// Add leading 0x or 0X.
+		buf = append(buf, '0', digits[16])
+	}
+	var c byte
+	for i := 0; i < length; i++ {
+		if f.space && i > 0 {
+			// Separate elements with a space.
+			buf = append(buf, ' ')
+			if f.sharp {
+				// Add leading 0x or 0X for each element.
+				buf = append(buf, '0', digits[16])
+			}
+		}
+		if b != nil {
+			c = b[i] // Take a byte from the input byte slice.
+		} else {
+			c = s[i] // Take a byte from the input string.
+		}
+		// Encode each byte as two hexadecimal digits.
+		buf = append(buf, digits[c>>4], digits[c&0xF])
+	}
+	*f.buf = buf
+	// Handle padding to the right.
+	if f.widPresent && f.wid > width && f.minus {
+		f.writePadding(f.wid - width)
+	}
+}
+
+// fmtSx formats a string as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtSx(s, digits string) {
+	f.fmtSbx(s, nil, digits)
+}
+
+// fmtBx formats a byte slice as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtBx(b []byte, digits string) {
+	f.fmtSbx("", b, digits)
+}
+
+// fmtQ formats a string as a double-quoted, escaped Go string constant.
+// If f.sharp is set a raw (backquoted) string may be returned instead
+// if the string does not contain any control characters other than tab.
+func (f *fmt) fmtQ(s string) {
+	s = f.truncateString(s)
+	if f.sharp && strconv.CanBackquote(s) {
+		f.padString("`" + s + "`")
+		return
+	}
+	buf := f.intbuf[:0]
+	if f.plus {
+		f.pad(strconv.AppendQuoteToASCII(buf, s))
+	} else {
+		f.pad(strconv.AppendQuote(buf, s))
+	}
+}
+
+// fmtC formats an integer as a Unicode character.
+// If the character is not valid Unicode, it will print '\ufffd'.
+func (f *fmt) fmtC(c uint64) {
+	r := rune(c)
+	if c > utf8.MaxRune {
+		r = utf8.RuneError
+	}
+	buf := f.intbuf[:0]
+	w := utf8.EncodeRune(buf[:utf8.UTFMax], r)
+	f.pad(buf[:w])
+}
+
+// fmtQc formats an integer as a single-quoted, escaped Go character constant.
+// If the character is not valid Unicode, it will print '\ufffd'.
+func (f *fmt) fmtQc(c uint64) {
+	r := rune(c)
+	if c > utf8.MaxRune {
+		r = utf8.RuneError
+	}
+	buf := f.intbuf[:0]
+	if f.plus {
+		f.pad(strconv.AppendQuoteRuneToASCII(buf, r))
+	} else {
+		f.pad(strconv.AppendQuoteRune(buf, r))
+	}
+}
+
+// fmtFloat formats a float64. It assumes that verb is a valid format specifier
+// for strconv.AppendFloat and therefore fits into a byte.
+func (f *fmt) fmtFloat(v float64, size int, verb rune, prec int) {
+	// Explicit precision in format specifier overrules default precision.
+	if f.precPresent {
+		prec = f.prec
+	}
+	// Format number, reserving space for leading + sign if needed.
+	num := strconv.AppendFloat(f.intbuf[:1], v, byte(verb), prec, size)
+	if num[1] == '-' || num[1] == '+' {
+		num = num[1:]
+	} else {
+		num[0] = '+'
+	}
+	// f.space means to add a leading space instead of a "+" sign unless
+	// the sign is explicitly asked for by f.plus.
+	if f.space && num[0] == '+' && !f.plus {
+		num[0] = ' '
+	}
+	// Special handling for infinities and NaN,
+	// which don't look like a number so shouldn't be padded with zeros.
+	if num[1] == 'I' || num[1] == 'N' {
+		oldZero := f.zero
+		f.zero = false
+		// Remove sign before NaN if not asked for.
+		if num[1] == 'N' && !f.space && !f.plus {
+			num = num[1:]
+		}
+		f.pad(num)
+		f.zero = oldZero
+		return
+	}
+	// The sharp flag forces printing a decimal point for non-binary formats
+	// and retains trailing zeros, which we may need to restore.
+	if f.sharp && verb != 'b' {
+		digits := 0
+		switch verb {
+		case 'v', 'g', 'G', 'x':
+			digits = prec
+			// If no precision is set explicitly use a precision of 6.
+			if digits == -1 {
+				digits = 6
+			}
+		}
+
+		// Buffer pre-allocated with enough room for
+		// exponent notations of the form "e+123" or "p-1023".
+		var tailBuf [6]byte
+		tail := tailBuf[:0]
+
+		hasDecimalPoint := false
+		// Starting from i = 1 to skip sign at num[0].
+		for i := 1; i < len(num); i++ {
+			switch num[i] {
+			case '.':
+				hasDecimalPoint = true
+			case 'p', 'P':
+				tail = append(tail, num[i:]...)
+				num = num[:i]
+			case 'e', 'E':
+				if verb != 'x' && verb != 'X' {
+					tail = append(tail, num[i:]...)
+					num = num[:i]
+					break
+				}
+				fallthrough
+			default:
+				digits--
+			}
+		}
+		if !hasDecimalPoint {
+			num = append(num, '.')
+		}
+		for digits > 0 {
+			num = append(num, '0')
+			digits--
+		}
+		num = append(num, tail...)
+	}
+	// We want a sign if asked for and if the sign is not positive.
+	if f.plus || num[0] != '+' {
+		// If we're zero padding to the left we want the sign before the leading zeros.
+		// Achieve this by writing the sign out and then padding the unsigned number.
+		if f.zero && f.widPresent && f.wid > len(num) {
+			f.buf.writeByte(num[0])
+			f.writePadding(f.wid - len(num))
+			f.buf.write(num[1:])
+			return
+		}
+		f.pad(num)
+		return
+	}
+	// No sign to show and the number is positive; just print the unsigned number.
+	f.pad(num[1:])
+}

--- a/internal/hooks.go
+++ b/internal/hooks.go
@@ -1,0 +1,74 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package fmt
+
+// printArg overrides the original implementation by redirecting the
+// call to a substitute function in the printer, if available.
+func (p *pp) printArg(a interface{}, verb rune) {
+	if p.printArgSubstituteFn != nil {
+		p.substituteState = p.printArgSubstituteFn(p, a, verb)
+	} else {
+		p.printArgOrig(a, verb)
+	}
+}
+
+// InternalPrinter exposes pp to the redact package.
+type InternalPrinter = pp
+
+// InternalBuffer exposes buffer to the redact package.
+type InternalBuffer = buffer
+
+// NewInternalPrinter exposes pp allocation to the redact package.
+func NewInternalPrinter() *InternalPrinter { return newPrinter() }
+
+// SetHook connects an outer printer to the inner printer.
+func SetHook(
+	p *InternalPrinter, fn func(p *InternalPrinter, arg interface{}, verb rune) (newState int),
+) {
+	p.printArgSubstituteFn = fn
+}
+
+// Free exposes pp deallocation to the redact package.
+func Free(p *InternalPrinter) {
+	p.substituteState = 0
+	p.printArgSubstituteFn = nil
+	p.free()
+}
+
+// Buf exposes the string buffer to the redact package.
+func Buf(p *InternalPrinter) []byte { return []byte(p.buf) }
+
+// GetState exposes the state to the redact package.
+func GetState(p *InternalPrinter) int {
+	return p.substituteState
+}
+
+// SetState exposes the string buffer to the redact package.
+func SetState(p *InternalPrinter, b []byte) {
+	p.buf = buffer(b)
+	p.substituteState = len(p.buf)
+}
+
+// Append adds bytes to the buffer.
+func Append(p *InternalPrinter, b []byte) { p.buf.write(b) }
+
+// PrintArg exposes the printArgOrig() method to the redact package.
+func PrintArg(p *InternalPrinter, a interface{}, verb rune) { p.printArgOrig(a, verb) }
+
+// DoPrint exposes the doPrint() method to the redact package.
+func DoPrint(p *InternalPrinter, a []interface{}) { p.doPrint(a) }
+
+// DoPrintf exposes the doPrintf() method to the redact package.
+func DoPrintf(p *InternalPrinter, format string, a []interface{}) { p.doPrintf(format, a) }

--- a/internal/print.go
+++ b/internal/print.go
@@ -1,0 +1,1189 @@
+// Code generated from print.go.orig. DO NOT EDIT
+// GENERATED FILE DO NOT EDIT
+//
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	// CUSTOM: needed to avoid a type mismatch on Formatter.
+	origFmt "fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+	"unicode/utf8"
+
+	// CUSTOM: our own import since we can't use internal from go stdlib.
+	"github.com/cockroachdb/redact/internal/fmtsort"
+)
+
+// Strings for use with buffer.WriteString.
+// This is less overhead than using buffer.Write with byte arrays.
+const (
+	commaSpaceString  = ", "
+	nilAngleString    = "<nil>"
+	nilParenString    = "(nil)"
+	nilString         = "nil"
+	mapString         = "map["
+	percentBangString = "%!"
+	missingString     = "(MISSING)"
+	badIndexString    = "(BADINDEX)"
+	panicString       = "(PANIC="
+	extraString       = "%!(EXTRA "
+	badWidthString    = "%!(BADWIDTH)"
+	badPrecString     = "%!(BADPREC)"
+	noVerbString      = "%!(NOVERB)"
+	invReflectString  = "<invalid reflect.Value>"
+)
+
+// State represents the printer state passed to custom formatters.
+// It provides access to the io.Writer interface plus information about
+// the flags and options for the operand's format specifier.
+type State interface {
+	// Write is the function to call to emit formatted output to be printed.
+	Write(b []byte) (n int, err error)
+	// Width returns the value of the width option and whether it has been set.
+	Width() (wid int, ok bool)
+	// Precision returns the value of the precision option and whether it has been set.
+	Precision() (prec int, ok bool)
+
+	// Flag reports whether the flag c, a character, has been set.
+	Flag(c int) bool
+}
+
+// Formatter is the interface implemented by values with a custom formatter.
+// The implementation of Format may call Sprint(f) or Fprint(f) etc.
+// to generate its output.
+type Formatter interface {
+	// CUSTOM: refer to the original type, not the one defined here.
+	Format(f origFmt.State, c rune)
+}
+
+// Stringer is implemented by any value that has a String method,
+// which defines the ``native'' format for that value.
+// The String method is used to print values passed as an operand
+// to any format that accepts a string or to an unformatted printer
+// such as Print.
+type Stringer interface {
+	String() string
+}
+
+// GoStringer is implemented by any value that has a GoString method,
+// which defines the Go syntax for that value.
+// The GoString method is used to print values passed as an operand
+// to a %#v format.
+type GoStringer interface {
+	GoString() string
+}
+
+// Use simple []byte instead of bytes.Buffer to avoid large dependency.
+type buffer []byte
+
+func (b *buffer) write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) writeString(s string) {
+	*b = append(*b, s...)
+}
+
+func (b *buffer) writeByte(c byte) {
+	*b = append(*b, c)
+}
+
+func (bp *buffer) writeRune(r rune) {
+	if r < utf8.RuneSelf {
+		*bp = append(*bp, byte(r))
+		return
+	}
+
+	b := *bp
+	n := len(b)
+	for n+utf8.UTFMax > cap(b) {
+		b = append(b, 0)
+	}
+	w := utf8.EncodeRune(b[n:n+utf8.UTFMax], r)
+	*bp = b[:n+w]
+}
+
+// pp is used to store a printer's state and is reused with sync.Pool to avoid allocations.
+type pp struct {
+	buf buffer
+
+	// CUSTOM: hook fn for the redact package.
+	printArgSubstituteFn func(p *pp, a interface{}, verb rune) (newState int)
+	substituteState      int
+
+	// arg holds the current item, as an interface{}.
+	arg interface{}
+
+	// value is used instead of arg for reflect values.
+	value reflect.Value
+
+	// fmt is used to format basic items such as integers or strings.
+	fmt fmt
+
+	// reordered records whether the format string used argument reordering.
+	reordered bool
+	// goodArgNum records whether the most recent reordering directive was valid.
+	goodArgNum bool
+	// panicking is set by catchPanic to avoid infinite panic, recover, panic, ... recursion.
+	panicking bool
+	// erroring is set when printing an error string to guard against calling handleMethods.
+	erroring bool
+	// wrapErrs is set when the format string may contain a %w verb.
+	wrapErrs bool
+	// wrappedErr records the target of the %w verb.
+	wrappedErr error
+}
+
+var ppFree = sync.Pool{
+	New: func() interface{} { return new(pp) },
+}
+
+// newPrinter allocates a new pp struct or grabs a cached one.
+func newPrinter() *pp {
+	p := ppFree.Get().(*pp)
+	p.panicking = false
+	p.erroring = false
+	p.wrapErrs = false
+	p.fmt.init(&p.buf)
+	return p
+}
+
+// free saves used pp structs in ppFree; avoids an allocation per invocation.
+func (p *pp) free() {
+	// Proper usage of a sync.Pool requires each entry to have approximately
+	// the same memory cost. To obtain this property when the stored type
+	// contains a variably-sized buffer, we add a hard limit on the maximum buffer
+	// to place back in the pool.
+	//
+	// See https://golang.org/issue/23199
+	if cap(p.buf) > 64<<10 {
+		return
+	}
+
+	p.buf = p.buf[:0]
+	p.arg = nil
+	p.value = reflect.Value{}
+	p.wrappedErr = nil
+	ppFree.Put(p)
+}
+
+func (p *pp) Width() (wid int, ok bool) { return p.fmt.wid, p.fmt.widPresent }
+
+func (p *pp) Precision() (prec int, ok bool) { return p.fmt.prec, p.fmt.precPresent }
+
+func (p *pp) Flag(b int) bool {
+	switch b {
+	case '-':
+		return p.fmt.minus
+	case '+':
+		return p.fmt.plus || p.fmt.plusV
+	case '#':
+		return p.fmt.sharp || p.fmt.sharpV
+	case ' ':
+		return p.fmt.space
+	case '0':
+		return p.fmt.zero
+	}
+	return false
+}
+
+// Implement Write so we can call Fprintf on a pp (through State), for
+// recursive use in custom verbs.
+func (p *pp) Write(b []byte) (ret int, err error) {
+	p.buf.write(b)
+	return len(b), nil
+}
+
+// Implement WriteString so that we can call io.WriteString
+// on a pp (through state), for efficiency.
+func (p *pp) WriteString(s string) (ret int, err error) {
+	p.buf.writeString(s)
+	return len(s), nil
+}
+
+// These routines end in 'f' and take a format string.
+
+// Fprintf formats according to a format specifier and writes to w.
+// It returns the number of bytes written and any write error encountered.
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Printf formats according to a format specifier and writes to standard output.
+// It returns the number of bytes written and any write error encountered.
+func Printf(format string, a ...interface{}) (n int, err error) {
+	return Fprintf(os.Stdout, format, a...)
+}
+
+// Sprintf formats according to a format specifier and returns the resulting string.
+func Sprintf(format string, a ...interface{}) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// These routines do not take a format string
+
+// Fprint formats using the default formats for its operands and writes to w.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrint(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Print formats using the default formats for its operands and writes to standard output.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Print(a ...interface{}) (n int, err error) {
+	return Fprint(os.Stdout, a...)
+}
+
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Spaces are added between operands when neither is a string.
+func Sprint(a ...interface{}) string {
+	p := newPrinter()
+	p.doPrint(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// These routines end in 'ln', do not take a format string,
+// always add spaces between operands, and add a newline
+// after the last operand.
+
+// Fprintln formats using the default formats for its operands and writes to w.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrintln(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Println formats using the default formats for its operands and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Println(a ...interface{}) (n int, err error) {
+	return Fprintln(os.Stdout, a...)
+}
+
+// Sprintln formats using the default formats for its operands and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func Sprintln(a ...interface{}) string {
+	p := newPrinter()
+	p.doPrintln(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// getField gets the i'th field of the struct value.
+// If the field is itself is an interface, return a value for
+// the thing inside the interface, not the interface itself.
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}
+
+// tooLarge reports whether the magnitude of the integer is
+// too large to be used as a formatting width or precision.
+func tooLarge(x int) bool {
+	const max int = 1e6
+	return x > max || x < -max
+}
+
+// parsenum converts ASCII to integer.  num is 0 (and isnum is false) if no number present.
+func parsenum(s string, start, end int) (num int, isnum bool, newi int) {
+	if start >= end {
+		return 0, false, end
+	}
+	for newi = start; newi < end && '0' <= s[newi] && s[newi] <= '9'; newi++ {
+		if tooLarge(num) {
+			return 0, false, end // Overflow; crazy long number most likely.
+		}
+		num = num*10 + int(s[newi]-'0')
+		isnum = true
+	}
+	return
+}
+
+func (p *pp) unknownType(v reflect.Value) {
+	if !v.IsValid() {
+		p.buf.writeString(nilAngleString)
+		return
+	}
+	p.buf.writeByte('?')
+	p.buf.writeString(v.Type().String())
+	p.buf.writeByte('?')
+}
+
+func (p *pp) badVerb(verb rune) {
+	p.erroring = true
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeByte('(')
+	switch {
+	case p.arg != nil:
+		p.buf.writeString(reflect.TypeOf(p.arg).String())
+		p.buf.writeByte('=')
+		p.printArg(p.arg, 'v')
+	case p.value.IsValid():
+		p.buf.writeString(p.value.Type().String())
+		p.buf.writeByte('=')
+		p.printValue(p.value, 'v', 0)
+	default:
+		p.buf.writeString(nilAngleString)
+	}
+	p.buf.writeByte(')')
+	p.erroring = false
+}
+
+func (p *pp) fmtBool(v bool, verb rune) {
+	switch verb {
+	case 't', 'v':
+		p.fmt.fmtBoolean(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmt0x64 formats a uint64 in hexadecimal and prefixes it with 0x or
+// not, as requested, by temporarily setting the sharp flag.
+func (p *pp) fmt0x64(v uint64, leading0x bool) {
+	sharp := p.fmt.sharp
+	p.fmt.sharp = leading0x
+	p.fmt.fmtInteger(v, 16, unsigned, 'v', ldigits)
+	p.fmt.sharp = sharp
+}
+
+// fmtInteger formats a signed or unsigned integer.
+func (p *pp) fmtInteger(v uint64, isSigned bool, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV && !isSigned {
+			p.fmt0x64(v, true)
+		} else {
+			p.fmt.fmtInteger(v, 10, isSigned, verb, ldigits)
+		}
+	case 'd':
+		p.fmt.fmtInteger(v, 10, isSigned, verb, ldigits)
+	case 'b':
+		p.fmt.fmtInteger(v, 2, isSigned, verb, ldigits)
+	case 'o', 'O':
+		p.fmt.fmtInteger(v, 8, isSigned, verb, ldigits)
+	case 'x':
+		p.fmt.fmtInteger(v, 16, isSigned, verb, ldigits)
+	case 'X':
+		p.fmt.fmtInteger(v, 16, isSigned, verb, udigits)
+	case 'c':
+		p.fmt.fmtC(v)
+	case 'q':
+		if v <= utf8.MaxRune {
+			p.fmt.fmtQc(v)
+		} else {
+			p.badVerb(verb)
+		}
+	case 'U':
+		p.fmt.fmtUnicode(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtFloat formats a float. The default precision for each verb
+// is specified as last argument in the call to fmt_float.
+func (p *pp) fmtFloat(v float64, size int, verb rune) {
+	switch verb {
+	case 'v':
+		p.fmt.fmtFloat(v, size, 'g', -1)
+	case 'b', 'g', 'G', 'x', 'X':
+		p.fmt.fmtFloat(v, size, verb, -1)
+	case 'f', 'e', 'E':
+		p.fmt.fmtFloat(v, size, verb, 6)
+	case 'F':
+		p.fmt.fmtFloat(v, size, 'f', 6)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtComplex formats a complex number v with
+// r = real(v) and j = imag(v) as (r+ji) using
+// fmtFloat for r and j formatting.
+func (p *pp) fmtComplex(v complex128, size int, verb rune) {
+	// Make sure any unsupported verbs are found before the
+	// calls to fmtFloat to not generate an incorrect error string.
+	switch verb {
+	case 'v', 'b', 'g', 'G', 'x', 'X', 'f', 'F', 'e', 'E':
+		oldPlus := p.fmt.plus
+		p.buf.writeByte('(')
+		p.fmtFloat(real(v), size/2, verb)
+		// Imaginary part always has a sign.
+		p.fmt.plus = true
+		p.fmtFloat(imag(v), size/2, verb)
+		p.buf.writeString("i)")
+		p.fmt.plus = oldPlus
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtString(v string, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.fmt.fmtQ(v)
+		} else {
+			p.fmt.fmtS(v)
+		}
+	case 's':
+		p.fmt.fmtS(v)
+	case 'x':
+		p.fmt.fmtSx(v, ldigits)
+	case 'X':
+		p.fmt.fmtSx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtBytes(v []byte, verb rune, typeString string) {
+	switch verb {
+	case 'v', 'd':
+		if p.fmt.sharpV {
+			p.buf.writeString(typeString)
+			if v == nil {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.writeString(commaSpaceString)
+				}
+				p.fmt0x64(uint64(c), true)
+			}
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte('[')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.writeByte(' ')
+				}
+				p.fmt.fmtInteger(uint64(c), 10, unsigned, verb, ldigits)
+			}
+			p.buf.writeByte(']')
+		}
+	case 's':
+		p.fmt.fmtBs(v)
+	case 'x':
+		p.fmt.fmtBx(v, ldigits)
+	case 'X':
+		p.fmt.fmtBx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(string(v))
+	default:
+		p.printValue(reflect.ValueOf(v), verb, 0)
+	}
+}
+
+func (p *pp) fmtPointer(value reflect.Value, verb rune) {
+	var u uintptr
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		u = value.Pointer()
+	default:
+		p.badVerb(verb)
+		return
+	}
+
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.buf.writeByte('(')
+			p.buf.writeString(value.Type().String())
+			p.buf.writeString(")(")
+			if u == 0 {
+				p.buf.writeString(nilString)
+			} else {
+				p.fmt0x64(uint64(u), true)
+			}
+			p.buf.writeByte(')')
+		} else {
+			if u == 0 {
+				p.fmt.padString(nilAngleString)
+			} else {
+				p.fmt0x64(uint64(u), !p.fmt.sharp)
+			}
+		}
+	case 'p':
+		p.fmt0x64(uint64(u), !p.fmt.sharp)
+	case 'b', 'o', 'd', 'x', 'X':
+		p.fmtInteger(uint64(u), unsigned, verb)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) catchPanic(arg interface{}, verb rune, method string) {
+	if err := recover(); err != nil {
+		// If it's a nil pointer, just say "<nil>". The likeliest causes are a
+		// Stringer that fails to guard against nil or a nil pointer for a
+		// value receiver, and in either case, "<nil>" is a nice result.
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Ptr && v.IsNil() {
+			p.buf.writeString(nilAngleString)
+			return
+		}
+		// Otherwise print a concise panic message. Most of the time the panic
+		// value will print itself nicely.
+		if p.panicking {
+			// Nested panics; the recursion in printArg cannot succeed.
+			panic(err)
+		}
+
+		oldFlags := p.fmt.fmtFlags
+		// For this output we want default behavior.
+		p.fmt.clearflags()
+
+		p.buf.writeString(percentBangString)
+		p.buf.writeRune(verb)
+		p.buf.writeString(panicString)
+		p.buf.writeString(method)
+		p.buf.writeString(" method: ")
+		p.panicking = true
+		p.printArg(err, 'v')
+		p.panicking = false
+		p.buf.writeByte(')')
+
+		p.fmt.fmtFlags = oldFlags
+	}
+}
+
+func (p *pp) handleMethods(verb rune) (handled bool) {
+	if p.erroring {
+		return
+	}
+	if verb == 'w' {
+		// It is invalid to use %w other than with Errorf, more than once,
+		// or with a non-error arg.
+		err, ok := p.arg.(error)
+		if !ok || !p.wrapErrs || p.wrappedErr != nil {
+			p.wrappedErr = nil
+			p.wrapErrs = false
+			p.badVerb(verb)
+			return true
+		}
+		p.wrappedErr = err
+		// If the arg is a Formatter, pass 'v' as the verb to it.
+		verb = 'v'
+	}
+
+	// Is it a Formatter?
+	if formatter, ok := p.arg.(Formatter); ok {
+		handled = true
+		defer p.catchPanic(p.arg, verb, "Format")
+		formatter.Format(p, verb)
+		return
+	}
+
+	// If we're doing Go syntax and the argument knows how to supply it, take care of it now.
+	if p.fmt.sharpV {
+		if stringer, ok := p.arg.(GoStringer); ok {
+			handled = true
+			defer p.catchPanic(p.arg, verb, "GoString")
+			// Print the result of GoString unadorned.
+			p.fmt.fmtS(stringer.GoString())
+			return
+		}
+	} else {
+		// If a string is acceptable according to the format, see if
+		// the value satisfies one of the string-valued interfaces.
+		// Println etc. set verb to %v, which is "stringable".
+		switch verb {
+		case 'v', 's', 'x', 'X', 'q':
+			// Is it an error or Stringer?
+			// The duplication in the bodies is necessary:
+			// setting handled and deferring catchPanic
+			// must happen before calling the method.
+			switch v := p.arg.(type) {
+			case error:
+				handled = true
+				defer p.catchPanic(p.arg, verb, "Error")
+				p.fmtString(v.Error(), verb)
+				return
+
+			case Stringer:
+				handled = true
+				defer p.catchPanic(p.arg, verb, "String")
+				p.fmtString(v.String(), verb)
+				return
+			}
+		}
+	}
+	return false
+}
+
+// CUSTOM: printArg() renamed to printArgOrig().
+func (p *pp) printArgOrig(arg interface{}, verb rune) {
+	p.arg = arg
+	p.value = reflect.Value{}
+
+	if arg == nil {
+		switch verb {
+		case 'T', 'v':
+			p.fmt.padString(nilAngleString)
+		default:
+			p.badVerb(verb)
+		}
+		return
+	}
+
+	// Special processing considerations.
+	// %T (the value's type) and %p (its address) are special; we always do them first.
+	switch verb {
+	case 'T':
+		p.fmt.fmtS(reflect.TypeOf(arg).String())
+		return
+	case 'p':
+		p.fmtPointer(reflect.ValueOf(arg), 'p')
+		return
+	}
+
+	// Some types can be done without reflection.
+	switch f := arg.(type) {
+	case bool:
+		p.fmtBool(f, verb)
+	case float32:
+		p.fmtFloat(float64(f), 32, verb)
+	case float64:
+		p.fmtFloat(f, 64, verb)
+	case complex64:
+		p.fmtComplex(complex128(f), 64, verb)
+	case complex128:
+		p.fmtComplex(f, 128, verb)
+	case int:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int8:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int16:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int32:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int64:
+		p.fmtInteger(uint64(f), signed, verb)
+	case uint:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint8:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint16:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint32:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint64:
+		p.fmtInteger(f, unsigned, verb)
+	case uintptr:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case string:
+		p.fmtString(f, verb)
+	case []byte:
+		p.fmtBytes(f, verb, "[]byte")
+	case reflect.Value:
+		// Handle extractable values with special methods
+		// since printValue does not handle them at depth 0.
+		if f.IsValid() && f.CanInterface() {
+			p.arg = f.Interface()
+			if p.handleMethods(verb) {
+				return
+			}
+		}
+		p.printValue(f, verb, 0)
+	default:
+		// If the type is not simple, it might have methods.
+		if !p.handleMethods(verb) {
+			// Need to use reflection, since the type had no
+			// interface methods that could be used for formatting.
+			p.printValue(reflect.ValueOf(f), verb, 0)
+		}
+	}
+}
+
+// printValue is similar to printArg but starts with a reflect value, not an interface{} value.
+// It does not handle 'p' and 'T' verbs because these should have been already handled by printArg.
+func (p *pp) printValue(value reflect.Value, verb rune, depth int) {
+	// Handle values with special methods if not already handled by printArg (depth == 0).
+	if depth > 0 && value.IsValid() && value.CanInterface() {
+		p.arg = value.Interface()
+		if p.handleMethods(verb) {
+			return
+		}
+	}
+	p.arg = nil
+	p.value = value
+
+	switch f := value; value.Kind() {
+	case reflect.Invalid:
+		if depth == 0 {
+			p.buf.writeString(invReflectString)
+		} else {
+			switch verb {
+			case 'v':
+				p.buf.writeString(nilAngleString)
+			default:
+				p.badVerb(verb)
+			}
+		}
+	case reflect.Bool:
+		p.fmtBool(f.Bool(), verb)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.fmtInteger(uint64(f.Int()), signed, verb)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.fmtInteger(f.Uint(), unsigned, verb)
+	case reflect.Float32:
+		p.fmtFloat(f.Float(), 32, verb)
+	case reflect.Float64:
+		p.fmtFloat(f.Float(), 64, verb)
+	case reflect.Complex64:
+		p.fmtComplex(f.Complex(), 64, verb)
+	case reflect.Complex128:
+		p.fmtComplex(f.Complex(), 128, verb)
+	case reflect.String:
+		p.fmtString(f.String(), verb)
+	case reflect.Map:
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+			if f.IsNil() {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+		} else {
+			p.buf.writeString(mapString)
+		}
+		sorted := fmtsort.Sort(f)
+		for i, key := range sorted.Key {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.writeString(commaSpaceString)
+				} else {
+					p.buf.writeByte(' ')
+				}
+			}
+			p.printValue(key, verb, depth+1)
+			p.buf.writeByte(':')
+			p.printValue(sorted.Value[i], verb, depth+1)
+		}
+		if p.fmt.sharpV {
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte(']')
+		}
+	case reflect.Struct:
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+		}
+		p.buf.writeByte('{')
+		for i := 0; i < f.NumField(); i++ {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.writeString(commaSpaceString)
+				} else {
+					p.buf.writeByte(' ')
+				}
+			}
+			if p.fmt.plusV || p.fmt.sharpV {
+				if name := f.Type().Field(i).Name; name != "" {
+					p.buf.writeString(name)
+					p.buf.writeByte(':')
+				}
+			}
+			p.printValue(getField(f, i), verb, depth+1)
+		}
+		p.buf.writeByte('}')
+	case reflect.Interface:
+		value := f.Elem()
+		if !value.IsValid() {
+			if p.fmt.sharpV {
+				p.buf.writeString(f.Type().String())
+				p.buf.writeString(nilParenString)
+			} else {
+				p.buf.writeString(nilAngleString)
+			}
+		} else {
+			p.printValue(value, verb, depth+1)
+		}
+	case reflect.Array, reflect.Slice:
+		switch verb {
+		case 's', 'q', 'x', 'X':
+			// Handle byte and uint8 slices and arrays special for the above verbs.
+			t := f.Type()
+			if t.Elem().Kind() == reflect.Uint8 {
+				var bytes []byte
+				if f.Kind() == reflect.Slice {
+					bytes = f.Bytes()
+				} else if f.CanAddr() {
+					bytes = f.Slice(0, f.Len()).Bytes()
+				} else {
+					// We have an array, but we cannot Slice() a non-addressable array,
+					// so we build a slice by hand. This is a rare case but it would be nice
+					// if reflection could help a little more.
+					bytes = make([]byte, f.Len())
+					for i := range bytes {
+						bytes[i] = byte(f.Index(i).Uint())
+					}
+				}
+				p.fmtBytes(bytes, verb, t.String())
+				return
+			}
+		}
+		if p.fmt.sharpV {
+			p.buf.writeString(f.Type().String())
+			if f.Kind() == reflect.Slice && f.IsNil() {
+				p.buf.writeString(nilParenString)
+				return
+			}
+			p.buf.writeByte('{')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.writeString(commaSpaceString)
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.writeByte('}')
+		} else {
+			p.buf.writeByte('[')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.writeByte(' ')
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.writeByte(']')
+		}
+	case reflect.Ptr:
+		// pointer to array or slice or struct? ok at top level
+		// but not embedded (avoid loops)
+		if depth == 0 && f.Pointer() != 0 {
+			switch a := f.Elem(); a.Kind() {
+			case reflect.Array, reflect.Slice, reflect.Struct, reflect.Map:
+				p.buf.writeByte('&')
+				p.printValue(a, verb, depth+1)
+				return
+			}
+		}
+		fallthrough
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		p.fmtPointer(f, verb)
+	default:
+		p.unknownType(f)
+	}
+}
+
+// intFromArg gets the argNumth element of a. On return, isInt reports whether the argument has integer type.
+func intFromArg(a []interface{}, argNum int) (num int, isInt bool, newArgNum int) {
+	newArgNum = argNum
+	if argNum < len(a) {
+		num, isInt = a[argNum].(int) // Almost always OK.
+		if !isInt {
+			// Work harder.
+			switch v := reflect.ValueOf(a[argNum]); v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				n := v.Int()
+				if int64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				n := v.Uint()
+				if int64(n) >= 0 && uint64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			default:
+				// Already 0, false.
+			}
+		}
+		newArgNum = argNum + 1
+		if tooLarge(num) {
+			num = 0
+			isInt = false
+		}
+	}
+	return
+}
+
+// parseArgNumber returns the value of the bracketed number, minus 1
+// (explicit argument numbers are one-indexed but we want zero-indexed).
+// The opening bracket is known to be present at format[0].
+// The returned values are the index, the number of bytes to consume
+// up to the closing paren, if present, and whether the number parsed
+// ok. The bytes to consume will be 1 if no closing paren is present.
+func parseArgNumber(format string) (index int, wid int, ok bool) {
+	// There must be at least 3 bytes: [n].
+	if len(format) < 3 {
+		return 0, 1, false
+	}
+
+	// Find closing bracket.
+	for i := 1; i < len(format); i++ {
+		if format[i] == ']' {
+			width, ok, newi := parsenum(format, 1, i)
+			if !ok || newi != i {
+				return 0, i + 1, false
+			}
+			return width - 1, i + 1, true // arg numbers are one-indexed and skip paren.
+		}
+	}
+	return 0, 1, false
+}
+
+// argNumber returns the next argument to evaluate, which is either the value of the passed-in
+// argNum or the value of the bracketed integer that begins format[i:]. It also returns
+// the new value of i, that is, the index of the next byte of the format to process.
+func (p *pp) argNumber(argNum int, format string, i int, numArgs int) (newArgNum, newi int, found bool) {
+	if len(format) <= i || format[i] != '[' {
+		return argNum, i, false
+	}
+	p.reordered = true
+	index, wid, ok := parseArgNumber(format[i:])
+	if ok && 0 <= index && index < numArgs {
+		return index, i + wid, true
+	}
+	p.goodArgNum = false
+	return argNum, i + wid, ok
+}
+
+func (p *pp) badArgNum(verb rune) {
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeString(badIndexString)
+}
+
+func (p *pp) missingArg(verb rune) {
+	p.buf.writeString(percentBangString)
+	p.buf.writeRune(verb)
+	p.buf.writeString(missingString)
+}
+
+func (p *pp) doPrintf(format string, a []interface{}) {
+	end := len(format)
+	argNum := 0         // we process one argument per non-trivial format
+	afterIndex := false // previous item in format was an index like [3].
+	p.reordered = false
+formatLoop:
+	for i := 0; i < end; {
+		p.goodArgNum = true
+		lasti := i
+		for i < end && format[i] != '%' {
+			i++
+		}
+		if i > lasti {
+			p.buf.writeString(format[lasti:i])
+		}
+		if i >= end {
+			// done processing format string
+			break
+		}
+
+		// Process one verb
+		i++
+
+		// Do we have flags?
+		p.fmt.clearflags()
+	simpleFormat:
+		for ; i < end; i++ {
+			c := format[i]
+			switch c {
+			case '#':
+				p.fmt.sharp = true
+			case '0':
+				p.fmt.zero = !p.fmt.minus // Only allow zero padding to the left.
+			case '+':
+				p.fmt.plus = true
+			case '-':
+				p.fmt.minus = true
+				p.fmt.zero = false // Do not pad with zeros to the right.
+			case ' ':
+				p.fmt.space = true
+			default:
+				// Fast path for common case of ascii lower case simple verbs
+				// without precision or width or argument indices.
+				if 'a' <= c && c <= 'z' && argNum < len(a) {
+					if c == 'v' {
+						// Go syntax
+						p.fmt.sharpV = p.fmt.sharp
+						p.fmt.sharp = false
+						// Struct-field syntax
+						p.fmt.plusV = p.fmt.plus
+						p.fmt.plus = false
+					}
+					p.printArg(a[argNum], rune(c))
+					argNum++
+					i++
+					continue formatLoop
+				}
+				// Format is more complex than simple flags and a verb or is malformed.
+				break simpleFormat
+			}
+		}
+
+		// Do we have an explicit argument index?
+		argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+
+		// Do we have width?
+		if i < end && format[i] == '*' {
+			i++
+			p.fmt.wid, p.fmt.widPresent, argNum = intFromArg(a, argNum)
+
+			if !p.fmt.widPresent {
+				p.buf.writeString(badWidthString)
+			}
+
+			// We have a negative width, so take its value and ensure
+			// that the minus flag is set
+			if p.fmt.wid < 0 {
+				p.fmt.wid = -p.fmt.wid
+				p.fmt.minus = true
+				p.fmt.zero = false // Do not pad with zeros to the right.
+			}
+			afterIndex = false
+		} else {
+			p.fmt.wid, p.fmt.widPresent, i = parsenum(format, i, end)
+			if afterIndex && p.fmt.widPresent { // "%[3]2d"
+				p.goodArgNum = false
+			}
+		}
+
+		// Do we have precision?
+		if i+1 < end && format[i] == '.' {
+			i++
+			if afterIndex { // "%[3].2d"
+				p.goodArgNum = false
+			}
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+			if i < end && format[i] == '*' {
+				i++
+				p.fmt.prec, p.fmt.precPresent, argNum = intFromArg(a, argNum)
+				// Negative precision arguments don't make sense
+				if p.fmt.prec < 0 {
+					p.fmt.prec = 0
+					p.fmt.precPresent = false
+				}
+				if !p.fmt.precPresent {
+					p.buf.writeString(badPrecString)
+				}
+				afterIndex = false
+			} else {
+				p.fmt.prec, p.fmt.precPresent, i = parsenum(format, i, end)
+				if !p.fmt.precPresent {
+					p.fmt.prec = 0
+					p.fmt.precPresent = true
+				}
+			}
+		}
+
+		if !afterIndex {
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+		}
+
+		if i >= end {
+			p.buf.writeString(noVerbString)
+			break
+		}
+
+		verb, size := rune(format[i]), 1
+		if verb >= utf8.RuneSelf {
+			verb, size = utf8.DecodeRuneInString(format[i:])
+		}
+		i += size
+
+		switch {
+		case verb == '%': // Percent does not absorb operands and ignores f.wid and f.prec.
+			p.buf.writeByte('%')
+		case !p.goodArgNum:
+			p.badArgNum(verb)
+		case argNum >= len(a): // No argument left over to print for the current verb.
+			p.missingArg(verb)
+		case verb == 'v':
+			// Go syntax
+			p.fmt.sharpV = p.fmt.sharp
+			p.fmt.sharp = false
+			// Struct-field syntax
+			p.fmt.plusV = p.fmt.plus
+			p.fmt.plus = false
+			fallthrough
+		default:
+			p.printArg(a[argNum], verb)
+			argNum++
+		}
+	}
+
+	// Check for extra arguments unless the call accessed the arguments
+	// out of order, in which case it's too expensive to detect if they've all
+	// been used and arguably OK if they're not.
+	if !p.reordered && argNum < len(a) {
+		p.fmt.clearflags()
+		p.buf.writeString(extraString)
+		for i, arg := range a[argNum:] {
+			if i > 0 {
+				p.buf.writeString(commaSpaceString)
+			}
+			if arg == nil {
+				p.buf.writeString(nilAngleString)
+			} else {
+				p.buf.writeString(reflect.TypeOf(arg).String())
+				p.buf.writeByte('=')
+				p.printArg(arg, 'v')
+			}
+		}
+		p.buf.writeByte(')')
+	}
+}
+
+func (p *pp) doPrint(a []interface{}) {
+	prevString := false
+	for argNum, arg := range a {
+		isString := arg != nil && reflect.TypeOf(arg).Kind() == reflect.String
+		// Add a space between two non-string arguments.
+		if argNum > 0 && !isString && !prevString {
+			p.buf.writeByte(' ')
+		}
+		p.printArg(arg, 'v')
+		prevString = isString
+	}
+}
+
+// doPrintln is like doPrint but always adds a space between arguments
+// and a newline after the last argument.
+func (p *pp) doPrintln(a []interface{}) {
+	for argNum, arg := range a {
+		if argNum > 0 {
+			p.buf.writeByte(' ')
+		}
+		p.printArg(arg, 'v')
+	}
+	p.buf.writeByte('\n')
+}

--- a/internal/print.go.diff
+++ b/internal/print.go.diff
@@ -1,0 +1,58 @@
+--- print.go.orig	2020-08-26 14:49:30.396184000 +0200
++++ print.go	2020-08-26 14:50:29.330829000 +0200
+@@ -1,3 +1,6 @@
++// Code generated from print.go.orig. DO NOT EDIT
++// GENERATED FILE DO NOT EDIT
++//
+ // Copyright 2009 The Go Authors. All rights reserved.
+ // Use of this source code is governed by a BSD-style
+ // license that can be found in the LICENSE file.
+@@ -5,12 +8,16 @@
+ package fmt
+ 
+ import (
+-	"internal/fmtsort"
++	// CUSTOM: needed to avoid a type mismatch on Formatter.
++	origFmt "fmt"
+ 	"io"
+ 	"os"
+ 	"reflect"
+ 	"sync"
+ 	"unicode/utf8"
++
++	// CUSTOM: our own import since we can't use internal from go stdlib.
++	"github.com/cockroachdb/redact/internal/fmtsort"
+ )
+ 
+ // Strings for use with buffer.WriteString.
+@@ -51,7 +58,8 @@
+ // The implementation of Format may call Sprint(f) or Fprint(f) etc.
+ // to generate its output.
+ type Formatter interface {
+-	Format(f State, c rune)
++	// CUSTOM: refer to the original type, not the one defined here.
++	Format(f origFmt.State, c rune)
+ }
+ 
+ // Stringer is implemented by any value that has a String method,
+@@ -105,6 +113,10 @@
+ type pp struct {
+ 	buf buffer
+ 
++	// CUSTOM: hook fn for the redact package.
++	printArgSubstituteFn func(p *pp, a interface{}, verb rune) (newState int)
++	substituteState      int
++
+ 	// arg holds the current item, as an interface{}.
+ 	arg interface{}
+ 
+@@ -635,7 +647,8 @@
+ 	return false
+ }
+ 
+-func (p *pp) printArg(arg interface{}, verb rune) {
++// CUSTOM: printArg() renamed to printArgOrig().
++func (p *pp) printArgOrig(arg interface{}, verb rune) {
+ 	p.arg = arg
+ 	p.value = reflect.Value{}
+ 

--- a/internal/refresh.sh
+++ b/internal/refresh.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# This file re-generates the sources in this directory from the Go
+# standard library.
+#
+set -euxo pipefail
+
+(
+    echo "// Code generated from the Go standard library. DO NOT EDIT"
+    echo "// GENERATED FILE DO NOT EDIT"
+    cat $GOROOT/src/fmt/format.go
+) >format.go
+
+cp $GOROOT/src/fmt/print.go print.go
+patch -p0 <print.go.diff
+
+mkdir -p fmtsort
+for a in $GOROOT/src/internal/fmtsort/*; do
+    if expr "$a" : ".*_test.go"; then
+	continue
+    fi
+    n=$(basename "$a")
+    (
+	echo "// Code generated from the Go standard library. DO NOT EDIT"
+	echo "// GENERATED FILE DO NOT EDIT"
+	cat "$a"
+    ) >fmtsort/"$n"
+done
+

--- a/markers_internal_escape.go
+++ b/markers_internal_escape.go
@@ -74,10 +74,11 @@ func (p *escapeWriter) Write(b []byte) (int, error) {
 	// entirely if there was nothing but empty space:
 	// if len(b) == 0 { return 0, nil }
 
-	start := startRedactableBytes
-	ls := len(startRedactableS)
-	end := endRedactableBytes
-	le := len(endRedactableS)
+	// Note: we use len(...RedactableS) and not len(...RedactableBytes)
+	// because the ...S variant is a compile-time constant so this
+	// accelerates the loops below.
+	start, ls := startRedactableBytes, len(startRedactableS)
+	end, le := endRedactableBytes, len(endRedactableS)
 	escape := escapeBytes
 
 	if p.enclose {
@@ -85,7 +86,11 @@ func (p *escapeWriter) Write(b []byte) (int, error) {
 	}
 
 	// Now write the string.
+
+	// k is the index in b up to (and excluding) the byte which we've
+	// already copied into the output.
 	k := 0
+
 	for i := 0; i < len(b); i++ {
 		if b[i] == '\n' && p.enclose {
 			// Avoid enclosing newline characters inside redaction markers.
@@ -94,29 +99,36 @@ func (p *escapeWriter) Write(b []byte) (int, error) {
 			// separately.
 			st = p.doWrite(b[k:i], st, true)
 			st = p.doWrite(end, st, false)
+			// Advance to the last newline character. We want to forward
+			// them all in a single call to doWrite, for performance.
 			lastNewLine := i
 			for b[lastNewLine] == '\n' && lastNewLine < len(b) {
 				lastNewLine++
 			}
 			st = p.doWrite(b[i:lastNewLine], st, true)
 			st = p.doWrite(start, st, false)
+			// Advance the counters by the number of newline characters.
 			k = lastNewLine
-			i = lastNewLine - 1
+			i = lastNewLine - 1 /* -1 because we have i++ at the end of every iteration */
 		} else {
 			// Ensure that occurrences of the delimiter inside the string get
 			// escaped.
+			// Reminder: ls and le are likely greater than 1, as we are scanning
+			// utf-8 encoded delimiters (the utf-8 encoding is multibyte).
 			if i+ls <= len(b) && bytes.Equal(b[i:i+ls], start) {
 				st = p.doWrite(b[k:i], st, true)
 				st = p.doWrite(escape, st, false)
+				// Advance the counters by the length (in bytes) of the delimiter.
 				st.l += ls
 				k = i + ls
-				i += ls - 1
+				i += ls - 1 /* -1 because we have i++ at the end of every iteration */
 			} else if i+le <= len(b) && bytes.Equal(b[i:i+le], end) {
 				st = p.doWrite(b[k:i], st, true)
 				st = p.doWrite(escape, st, false)
+				// Advance the counters by the length (in bytes) of the delimiter.
 				st.l += le
 				k = i + le
-				i += le - 1
+				i += le - 1 /* -1 because we have i++ at the end of every iteration */
 			}
 		}
 	}
@@ -144,4 +156,62 @@ func (p *escapeWriter) doWrite(b []byte, st escapeResult, count bool) escapeResu
 	}
 	st.err = err
 	return st
+}
+
+// internalEscapeBytes escapes redaction markers in the provided buf
+// starting at the location startLoc.
+// The bytes before startLoc are considered safe (already escaped).
+func internalEscapeBytes(b []byte, startLoc int) (res []byte) {
+	// Note: we use len(...RedactableS) and not len(...RedactableBytes)
+	// because the ...S variant is a compile-time constant so this
+	// accelerates the loops below.
+	start, ls := startRedactableBytes, len(startRedactableS)
+	end, le := endRedactableBytes, len(endRedactableS)
+	escape := escapeBytes
+
+	// res is the output slice. In the common case where there is
+	// nothing to escape, the input slice is returned directly
+	// and no allocation takes place.
+	res = b
+	// copied is true if and only if `res` is a copy of `b`.  It only
+	// turns to true if the loop below finds something to escape.
+	copied := false
+	// k is the index in b up to (and excluding) the byte which we've
+	// already copied into res (if copied=true).
+	k := 0
+
+	for i := startLoc; i < len(b); i++ {
+		// Ensure that occurrences of the delimiter inside the string get
+		// escaped.
+		// Reminder: ls and le are likely greater than 1, as we are scanning
+		// utf-8 encoded delimiters (the utf-8 encoding is multibyte).
+		if i+ls <= len(b) && bytes.Equal(b[i:i+ls], start) {
+			if !copied {
+				// We only allocate an output slice when we know we definitely
+				// need it.
+				res = make([]byte, 0, len(b)+len(escape))
+				copied = true
+			}
+			res = append(res, b[k:i]...)
+			res = append(res, escape...)
+			// Advance the counters by the length (in bytes) of the delimiter.
+			k = i + ls
+			i += ls - 1 /* -1 because we have i++ at the end of every iteration */
+		} else if i+le <= len(b) && bytes.Equal(b[i:i+le], end) {
+			if !copied {
+				// See the comment above about res allocation.
+				res = make([]byte, 0, len(b)+len(escape))
+				copied = true
+			}
+			res = append(res, b[k:i]...)
+			res = append(res, escape...)
+			// Advance the counters by the length (in bytes) of the delimiter.
+			k = i + le
+			i += le - 1 /* -1 because we have i++ at the end of every iteration */
+		}
+	}
+	if copied {
+		res = append(res, b[k:]...)
+	}
+	return
 }

--- a/markers_internal_print.go
+++ b/markers_internal_print.go
@@ -14,66 +14,100 @@
 
 package redact
 
-import "fmt"
+import (
+	"fmt"
 
-// annotateArgs wraps the arguments to one of the print functions with
-// an indirect formatter which either encloses the result of the
-// display between redaction markers, or not.
-func annotateArgs(args []interface{}) {
-	for i, arg := range args {
+	internalFmt "github.com/cockroachdb/redact/internal"
+)
+
+// printArgFn is the hook injected into the standard fmt logic
+// by the printer functions in markers_print.go.
+func printArgFn(p *internalFmt.InternalPrinter, arg interface{}, verb rune) (newState int) {
+	redactLastWrites(p)
+
+	if verb == 'T' {
+		// If the value was wrapped, reveal its original type. Anything else is not very useful.
 		switch v := arg.(type) {
-		case RedactableString:
-			// Already formatted as redactable. Include as-is.
-			// We need an intermediate struct because we don't
-			// want the fmt machinery to re-format the string
-			// object by adding quotes, expanding the byte slice, etc.
-			//
-			// NB: keep this logic synchronized with
-			// (RedactableString).SafeFormat().
-			args[i] = &passthrough{arg: []byte(v)}
+		case safeWrapper:
+			arg = v.a
+		case unsafeWrap:
+			arg = v.a
+		}
 
-		case RedactableBytes:
-			// NB: keep this logic synchronized with
-			// (RedactableBytes).SafeFormat().
-			args[i] = &passthrough{arg: v}
+		// Shortcut: %T is always safe to print as-is.
+		internalFmt.PrintArg(p, arg, verb)
+		return len(internalFmt.Buf(p))
+	}
 
-		case SafeFormatter:
-			// calls to Format() by fmt.Print will be redirected to
-			// v.SafeFormat(). This delegates the task of adding markers to
-			// the object itself.
-			args[i] = &redactFormatRedirect{
-				func(p SafePrinter, verb rune) { v.SafeFormat(p, verb) },
-			}
+	// RedactableBytes/RedactableString are already formatted as
+	// redactable. Include them as-is.
+	//
+	// NB: keep this logic synchronized with
+	// (RedactableString/Bytes).SafeFormat().
+	switch v := arg.(type) {
+	case RedactableString:
+		internalFmt.Append(p, []byte(v))
+		return len(internalFmt.Buf(p))
+	case RedactableBytes:
+		internalFmt.Append(p, []byte(v))
+		return len(internalFmt.Buf(p))
+	}
 
-		case SafeValue:
-			// calls to Format() by fmt.Print will be redirected to a
-			// display of v without redaction markers.
-			//
-			// Note that we can't let the value be displayed as-is because
-			// we must prevent any marker inside the value from leaking into
-			// the result. (We want to avoid mismatched markers.)
-			args[i] = &escapeArg{arg: arg, enclose: false}
+	arg = annotateArg(arg)
+	internalFmt.PrintArg(p, arg, verb)
+	return len(internalFmt.Buf(p))
+}
 
-		case SafeMessager:
-			// Obsolete interface.
-			// TODO(knz): Remove this.
-			args[i] = &escapeArg{arg: v.SafeMessage(), enclose: false}
+// redactLastWrites escapes any markers that were added by the
+// internals of the printf functions, for example
+// if markers were present in the format string.
+func redactLastWrites(p *internalFmt.InternalPrinter) {
+	state := internalFmt.GetState(p)
+	newBuf := internalEscapeBytes(internalFmt.Buf(p), state)
+	internalFmt.SetState(p, newBuf)
+}
 
-		default:
-			if err, ok := v.(error); ok && redactErrorFn != nil {
-				// We place this case after the other cases above, in case
-				// the error object knows how to print itself safely already.
-				args[i] = &redactFormatRedirect{
-					func(p SafePrinter, verb rune) { redactErrorFn(err, p, verb) },
-				}
-			} else {
-				// calls to Format() by fmt.Print will be redirected to a
-				// display of v within redaction markers if the type is
-				// considered unsafe, without markers otherwise. In any case,
-				// occurrences of delimiters within are escaped.
-				args[i] = &escapeArg{arg: v, enclose: !isSafeValue(v)}
+// annotateArg wraps the arguments to one of the print functions with
+// an indirect formatter which ensures that redaction markers inside
+// the representation of the object are escaped, and optionally
+// encloses the result of the display between redaction markers.
+func annotateArg(arg interface{}) interface{} {
+	switch v := arg.(type) {
+	case SafeFormatter:
+		// calls to Format() by fmt.Print will be redirected to
+		// v.SafeFormat(). This delegates the task of adding markers to
+		// the object itself.
+		return &redactFormatRedirect{
+			func(p SafePrinter, verb rune) { v.SafeFormat(p, verb) },
+		}
+
+	case SafeValue:
+		// calls to Format() by fmt.Print will be redirected to a
+		// display of v without redaction markers.
+		//
+		// Note that we can't let the value be displayed as-is because
+		// we must prevent any marker inside the value from leaking into
+		// the result. (We want to avoid mismatched markers.)
+		return &escapeArg{arg: arg, enclose: false}
+
+	case SafeMessager:
+		// Obsolete interface.
+		// TODO(knz): Remove this.
+		return &escapeArg{arg: v.SafeMessage(), enclose: false}
+
+	default:
+		if err, ok := v.(error); ok && redactErrorFn != nil {
+			// We place this case after the other cases above, in case
+			// the error object knows how to print itself safely already.
+			return &redactFormatRedirect{
+				func(p SafePrinter, verb rune) { redactErrorFn(err, p, verb) },
 			}
 		}
+		// calls to Format() by fmt.Print will be redirected to a
+		// display of v within redaction markers if the type is
+		// considered unsafe, without markers otherwise. In any case,
+		// occurrences of delimiters within are escaped.
+		return &escapeArg{arg: v, enclose: !isSafeValue(v)}
 	}
 }
 


### PR DESCRIPTION
Fixes #1

This patch imports the formatting logic from the go stdlib so as to
handle the `%T` formatting verb properly.

In the fmt package, `Print()` omits interleaving spaces if the last
argument has string type. Because this patch picks up the fmt code
as-is, this behavior is now adopted here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/redact/3)
<!-- Reviewable:end -->
