### PR TITLE
Make nil non-redactable

### DIFF
--- a/markers_internal_print.go
+++ b/markers_internal_print.go
@@ -39,6 +39,15 @@ func printArgFn(p *internalFmt.InternalPrinter, arg interface{}, verb rune) (new
 		return len(internalFmt.Buf(p))
 	}
 
+	// nil arguments are printed as-is. Note: a nil argument under
+	// interface{} is not the same as a nil pointer passed via a pointer
+	// of a concrete type. The latter kind of nil goes through
+	// redaction as usual, because it may have its own custom Format() method.
+	if arg == nil {
+		internalFmt.PrintArg(p, arg, verb)
+		return len(internalFmt.Buf(p))
+	}
+
 	// RedactableBytes/RedactableString are already formatted as
 	// redactable. Include them as-is.
 	//


### PR DESCRIPTION
Fixes #6 

This change ensures that a `nil` error or other interface-typed `nil`
value gets printed as `<nil>` without redaction markers.

Concretely typed `nil` pointers still get processed through the
regular redaction logic, as they may be unsafe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/redact/7)
<!-- Reviewable:end -->
