### PR TITLE
New APIs for safe numeric values

### DIFF
--- a/api.go
+++ b/api.go
@@ -69,12 +69,17 @@ type SafePrinter = i.SafePrinter
 // SafeFormatter, to format mixes of safe and unsafe strings.
 type SafeWriter = i.SafeWriter
 
-// SafeString aliases string. This is not meant to be used directly;
-// the type definition ensures that SafePrinter's SafeString method
-// can only take constant string literals as arguments. Typically, a
-// Go linter would ensure that ConstantString is never used to cast a
-// value.
+// SafeString represents a string that is not a sensitive value.
 type SafeString = i.SafeString
+
+// SafeInt represents an integer that is not a sensitive value.
+type SafeInt = i.SafeInt
+
+// SafeUint represents an integer that is not a sensitive value.
+type SafeUint = i.SafeUint
+
+// SafeFloat represents a floating-point value that is not a sensitive value.
+type SafeFloat = i.SafeFloat
 
 // SafeRune aliases rune. See the explanation for SafeString.
 type SafeRune = i.SafeRune

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -87,6 +87,24 @@ func (b *StringBuilder) SafeString(s i.SafeString) {
 	_, _ = b.Buffer.WriteString(string(s))
 }
 
+// SafeInt is part of the SafeWriter interface.
+func (b *StringBuilder) SafeInt(s i.SafeInt) {
+	b.SetMode(ib.SafeEscaped)
+	_, _ = ifmt.Fprintf(&b.Buffer, "%d", s)
+}
+
+// SafeUint is part of the SafeWriter interface.
+func (b *StringBuilder) SafeUint(s i.SafeUint) {
+	b.SetMode(ib.SafeEscaped)
+	_, _ = ifmt.Fprintf(&b.Buffer, "%d", s)
+}
+
+// SafeFloat is part of the SafeWriter interface.
+func (b *StringBuilder) SafeFloat(s i.SafeFloat) {
+	b.SetMode(ib.SafeEscaped)
+	_, _ = ifmt.Fprintf(&b.Buffer, "%v", s)
+}
+
 // SafeRune is part of the SafeWriter interface.
 func (b *StringBuilder) SafeRune(s i.SafeRune) {
 	b.SetMode(ib.SafeEscaped)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -43,6 +43,10 @@ func TestBuilder(t *testing.T) {
 
 	b.SafeString("safe\n")
 
+	b.SafeInt(123)
+	b.SafeUint(456)
+	b.SafeFloat(3.14)
+
 	b.SafeRune('S')
 	b.SafeRune('\n')
 
@@ -70,7 +74,7 @@ safe
 safe
 hello safe ‹unsafe›
 safe
-S
+1234563.14S
 ‹unsafe›
 ‹unsafe` + "\342" + `?›
 ‹U›
@@ -96,7 +100,7 @@ safe
 safe
 hello safe unsafe
 safe
-S
+1234563.14S
 unsafe
 unsafe` + "\342" + `?
 U

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -53,6 +53,15 @@ type SafeWriter interface {
 	// SafeString emits a safe string.
 	SafeString(SafeString)
 
+	// SafeInt emits a safe integer.
+	SafeInt(SafeInt)
+
+	// SafeUint emits a safe unsigned integer.
+	SafeUint(SafeUint)
+
+	// SafeFloat emits a safe floating-point value.
+	SafeFloat(SafeFloat)
+
 	// SafeRune emits a safe rune.
 	SafeRune(SafeRune)
 
@@ -80,15 +89,29 @@ type SafeWriter interface {
 	UnsafeRune(rune)
 }
 
-// SafeString aliases string. This is not meant to be used directly;
-// the type definition ensures that SafePrinter's SafeString method
-// can only take constant string literals as arguments. Typically, a
-// Go linter would ensure that ConstantString is never used to cast a
-// value.
+// SafeString represents a string that is not a sensitive value.
 type SafeString string
 
 // SafeValue makes SafeString a SafeValue.
 func (SafeString) SafeValue() {}
+
+// SafeInt represents an integer that is not a sensitive value.
+type SafeInt int64
+
+// SafeValue makes SafeInt a SafeValue.
+func (SafeInt) SafeValue() {}
+
+// SafeUint represents an integer that is not a sensitive value.
+type SafeUint uint64
+
+// SafeValue makes SafeUint a SafeValue.
+func (SafeUint) SafeValue() {}
+
+// SafeFloat represents a floating-point value that is not a sensitive value.
+type SafeFloat float64
+
+// SafeValue makes SafeFloat a SafeValue.
+func (SafeFloat) SafeValue() {}
 
 // SafeRune aliases rune. See the explanation for SafeString.
 type SafeRune rune

--- a/internal/rfmt/printer_adapter.go
+++ b/internal/rfmt/printer_adapter.go
@@ -22,6 +22,24 @@ func (p *pp) SafeString(s i.SafeString) {
 	p.buf.WriteString(string(s))
 }
 
+// SafeInt implements SafePrinter.
+func (p *pp) SafeInt(s i.SafeInt) {
+	defer p.startSafeOverride().restore()
+	p.fmtInteger(uint64(s), signed, 'd')
+}
+
+// SafeUint implements SafePrinter.
+func (p *pp) SafeUint(s i.SafeUint) {
+	defer p.startSafeOverride().restore()
+	p.fmtInteger(uint64(s), unsigned, 'd')
+}
+
+// SafeFloat implements SafePrinter.
+func (p *pp) SafeFloat(s i.SafeFloat) {
+	defer p.startSafeOverride().restore()
+	p.fmtFloat(float64(s), 64, 'v')
+}
+
 // SafeRune implements SafePrinter.
 func (p *pp) SafeRune(r i.SafeRune) {
 	defer p.startSafeOverride().restore()

--- a/markers_test.go
+++ b/markers_test.go
@@ -46,6 +46,9 @@ func TestPrinter(t *testing.T) {
 	}{
 		{func(w p) { w.SafeString("ab") }, `ab`},
 		{func(w p) { w.SafeRune('☃') }, `☃`},
+		{func(w p) { w.SafeInt(-123) }, `-123`},
+		{func(w p) { w.SafeUint(123) }, `123`},
+		{func(w p) { w.SafeFloat(3.14) }, `3.14`},
 		{func(w p) { w.UnsafeString("rs") }, `‹rs›`},
 		{func(w p) { w.UnsafeByte('t') }, `‹t›`},
 		{func(w p) { w.UnsafeByte(m.StartS[0]) }, `‹?›`},
@@ -61,6 +64,11 @@ func TestPrinter(t *testing.T) {
 		{func(w p) { w.Print("ar", []int{123, 456}) }, `‹ar›[‹123› ‹456›]`},
 		{func(w p) { w.Print("ar", []byte{55, 56}) }, `‹ar›[‹55› ‹56›]`},
 		{func(w p) { w.Print("ar", Safe([]byte{55, 56})) }, `‹ar›[55 56]`},
+
+		// Numeric values.
+		{func(w p) { w.Printf("vn %+d", SafeInt(123)) }, `vn +123`},
+		{func(w p) { w.Printf("vn %05d", SafeUint(123)) }, `vn 00123`},
+		{func(w p) { w.Printf("vn %e", SafeFloat(3.14)) }, `vn 3.140000e+00`},
 
 		// Pre-redactable strings.
 		{func(w p) { w.Print("pr", RedactableString("hi")) }, `‹pr›hi`},
@@ -125,6 +133,9 @@ func TestPrinter(t *testing.T) {
 		{func(w p) { w.Print(Unsafe(RedactableString("ab‹c›"))) }, "‹ab?c?›"},
 		{func(w p) { w.Print(Unsafe(RedactableBytes("ab‹c›"))) }, "‹ab?c?›"},
 		{func(w p) { w.Print(Unsafe(SafeRune('a'))) }, "‹97›"},
+		{func(w p) { w.Print(Unsafe(SafeInt(-123))) }, "‹-123›"},
+		{func(w p) { w.Print(Unsafe(SafeUint(123))) }, "‹123›"},
+		{func(w p) { w.Print(Unsafe(SafeFloat(3.14))) }, "‹3.14›"},
 		{func(w p) { w.Print(Unsafe(Sprint("abc"))) }, "‹?abc?›"},
 		{func(w p) { w.Print(Unsafe(Safe("abc"))) }, "‹abc›"},
 		{func(w p) { w.Printf("%v", Unsafe(SafeString("abc"))) }, "‹abc›"},


### PR DESCRIPTION
Fixes #16.
cc @jbowens  as this would have been useful in Pebble.

This introduces the following.

New basic types:

```go
// SafeInt represents an integer that is not a sensitive value.
type SafeInt

// SafeUint represents an integer that is not a sensitive value.
type SafeUint

// SafeFloat represents a floating-point value that is not a sensitive value.
type SafeFloat
```

New methods in `SafeWriter`:

```go
type SafeWriter interface {
    ...
    // SafeInt emits a safe integer.
    SafeInt(SafeInt)

    // SafeUint emits a safe unsigned integer.
    SafeUint(SafeUint)

    // SafeFloat emits a safe floating-point value.
    SafeFloat(SafeFloat)
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/redact/22)
<!-- Reviewable:end -->
