### PR TITLE
Ensure that StringBuilder implements accessors by value

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -32,6 +32,7 @@ type StringBuilder struct {
 	ib.Buffer
 }
 
+var _ fmt.Stringer = StringBuilder{}
 var _ fmt.Stringer = (*StringBuilder)(nil)
 
 // SafeFormat implements SafeFormatter.

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -111,4 +111,8 @@ UUU
 	if actual != expected {
 		t.Errorf("expected:\n%s\n\ngot:\n%s", expected, actual)
 	}
+
+	if actual := fmt.Sprintf("%v", b); actual != expected {
+		t.Errorf("expected:\n%s\n\ngot:\n%s", expected, actual)
+	}
 }

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -57,26 +57,30 @@ const (
 )
 
 // RedactableBytes returns the bytes in the buffer.
-func (b *Buffer) RedactableBytes() m.RedactableBytes {
-	copy := *b
-	copy.finalize()
-	return m.RedactableBytes(copy.buf)
+func (b Buffer) RedactableBytes() m.RedactableBytes {
+	// NB: we're dependent on the fact this is a copy of the original
+	// buffer. The finalize() method should not be called
+	// in a conceputally read-only accessor like RedactableBytes().
+	b.finalize()
+	return m.RedactableBytes(b.buf)
 }
 
 // RedactableString returns the bytes in the buffer.
-func (b *Buffer) RedactableString() m.RedactableString {
-	if b == nil {
-		// Special case, useful in debugging.
-		return "<nil>"
-	}
-	copy := *b
-	copy.finalize()
-	return m.RedactableString(copy.buf)
+func (b Buffer) RedactableString() m.RedactableString {
+	// NB: we're dependent on the fact this is a copy of the original
+	// buffer. The finalize() method should not be called
+	// in a conceputally read-only accessor like RedactableString().
+	b.finalize()
+	return m.RedactableString(b.buf)
 }
 
 // String implemens fmt.Stringer.
-func (b *Buffer) String() string {
-	return b.RedactableString().StripMarkers()
+func (b Buffer) String() string {
+	// NB: we're dependent on the fact this is a copy of the original
+	// buffer. The finalize() method should not be called
+	// in a conceputally read-only accessor like String().
+	b.finalize()
+	return m.RedactableString(b.buf).StripMarkers()
 }
 
 // TakeRedactableBytes returns the buffer


### PR DESCRIPTION
found via crdb's test suite:

```
=== RUN   TestLint/TestRoachVet
lint_test.go:110:
pkg/kv/kvserver/replica_application_state_machine.go:1057:42: github.com/cockroachdb/errors.AssertionFailedf format %s has arg req of wrong type github.com/cockroachdb/redact/builder.StringBuilder
pkg/kv/kvserver/replica_application_state_machine.go:1099:10: github.com/cockroachdb/errors.AssertionFailedf format %s has arg req of wrong type github.com/cockroachdb/redact/builder.StringBuilder
pkg/kv/kvserver/replica_range_lease.go:623:5: github.com/cockroachdb/cockroach/pkg/util/log.Infof format %s has arg msg of wrong type github.com/cockroachdb/redact/builder.StringBuilder
pkg/migration/migrationmanager/manager.go:329:3: github.com/cockroachdb/cockroach/pkg/util/log.Errorf format %s has arg buf of wrong type github.com/cockroachdb/redact/builder.StringBuilder
pkg/migration/migrationmanager/manager.go:330:20: github.com/cockroachdb/errors.AssertionFailedf format %s has arg buf of wrong type github.com/cockroachdb/redact/builder.StringBuilder
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/redact/24)
<!-- Reviewable:end -->
