### PR TITLE
builder: properly mark unsafe strings/bytes/runes as unsafe

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -67,6 +67,24 @@ func (b *StringBuilder) Write(s []byte) (int, error) {
 	return b.Buffer.Write(s)
 }
 
+// WriteString shadows the ib.Buffer.WriteString method.
+func (b *StringBuilder) WriteString(s string) (int, error) {
+	b.SetMode(ib.UnsafeEscaped)
+	return b.Buffer.WriteString(s)
+}
+
+// WriteByte shadows the ib.Buffer.WriteByte method.
+func (b *StringBuilder) WriteByte(c byte) error {
+	b.SetMode(ib.UnsafeEscaped)
+	return b.Buffer.WriteByte(c)
+}
+
+// WriteRune shadows the ib.Buffer.WriteRune method.
+func (b *StringBuilder) WriteRune(r rune) error {
+	b.SetMode(ib.UnsafeEscaped)
+	return b.Buffer.WriteRune(r)
+}
+
 // StringBuilder implements SafeWriter.
 var _ i.SafeWriter = (*StringBuilder)(nil)
 

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -116,3 +116,18 @@ UUU
 		t.Errorf("expected:\n%s\n\ngot:\n%s", expected, actual)
 	}
 }
+
+func TestMixedWrites(t *testing.T) {
+	var b StringBuilder
+	b.SafeString("safe")
+	b.WriteString("unsafe")
+	b.SafeString("")
+	b.WriteByte('U')
+	b.SafeString("")
+	b.WriteRune('U')
+	actual := b.RedactableString()
+	const expected = `safe‹unsafe›‹U›‹U›`
+	if actual != expected {
+		t.Errorf("expected:\n%s\n\ngot:\n%s", expected, actual)
+	}
+}


### PR DESCRIPTION
Needed for https://github.com/cockroachdb/cockroach/issues/103227

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/redact/28)
<!-- Reviewable:end -->
